### PR TITLE
Add stale issues & prs workflow

### DIFF
--- a/.github/workflows/stale-issues-and-prs.yml
+++ b/.github/workflows/stale-issues-and-prs.yml
@@ -1,0 +1,14 @@
+name: "Close stale Issues and PRs"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "Message to comment on stale issues. If none provided, will not mark issues stale"
+          stale-pr-message: "Message to comment on stale PRs. If none provided, will not mark PRs stale"


### PR DESCRIPTION
This adds a workflow that will mark unattended issues & pull requests as stale after a certain amount of time.