### PR TITLE
chore: update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,14 +15,13 @@ Please don't be shy and add as much context as you think necessary.
 - Closes #(issue)
 - Fixes #(issue)
 
-## ❓ Type of change
+## 🕵️‍♀️ QA
 
-(choose one or many and put ✅ before)
+Before requesting a review, please make sure that:
 
-⏹ Bug fix (non-breaking change which fixes an issue)
-⏹ New feature (non-breaking change which adds functionality)
-⏹ Breaking change (fix or feature that would cause existing functionality to not work as expected)
-⏹ Other: fill in the type of change
+- [ ] Preview is working on Netlify, Heroku or similar.
+- [ ] Manually check that it's working.
+- [ ] Add documentation and tests if needed.
 
 ## 📸 Screenshots
 


### PR DESCRIPTION
## ✍️ Description

Update PR template to remove type of change (since we agreed to use conventional commits for the PR title it's not needed anymore), and added a section for a few manual checks that should be check off before asking for review. The idea behind that is to encourage self review of a PR before asking others for review: for example, it's relatively common for JAMStack sites to behave a bit differently between dev mode and the generated version, so it's a good idea to double check that everything is working as expected (and avoid the famous, classic, and beloved "but it works in my machine").
